### PR TITLE
Fix callback already called

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -26,20 +26,6 @@ export default async function SvgChunkWebpackLoader(
 	const compiler = this._compiler;
 	const callback = this.async();
 
-	// Declare all SVG files as side effect
-	// https://github.com/webpack/webpack/issues/12202#issuecomment-745537821
-	this._module.factoryMeta = this._module.factoryMeta || {};
-	this._module.factoryMeta.sideEffectFree = false;
-
-	// Flag all SVG files to find them more easily on the plugin side
-	this._module.buildInfo.SVG_CHUNK_WEBPACK_PLUGIN = true;
-
-	// Check if content is a SVG file
-	if (!content.includes('<svg')) {
-		callback(new Error(`${PACKAGE_NAME} exception. ${content}`));
-		return;
-	}
-
 	// Check if the plugin is also imported
 	const plugin = compiler.options.plugins.find(
 		(plugin: any) => plugin.PLUGIN_NAME && plugin.PLUGIN_NAME === PACKAGE_NAME
@@ -48,6 +34,20 @@ export default async function SvgChunkWebpackLoader(
 		callback(new Error(`${PACKAGE_NAME} requires the corresponding plugin`));
 		return;
 	}
+
+	// Check if content is a SVG file
+	if (!content.includes('<svg')) {
+		callback(new Error(`${PACKAGE_NAME} exception. ${content}`));
+		return;
+	}
+
+	// Declare all SVG files as side effect
+	// https://github.com/webpack/webpack/issues/12202#issuecomment-745537821
+	this._module.factoryMeta = this._module.factoryMeta || {};
+	this._module.factoryMeta.sideEffectFree = false;
+
+	// Flag all SVG files to find them more easily on the plugin side
+	this._module.buildInfo.SVG_CHUNK_WEBPACK_PLUGIN = true;
 
 	try {
 		const { configFile } = options;

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -37,6 +37,7 @@ export default async function SvgChunkWebpackLoader(
 	// Check if content is a SVG file
 	if (!content.includes('<svg')) {
 		callback(new Error(`${PACKAGE_NAME} exception. ${content}`));
+		return;
 	}
 
 	// Check if the plugin is also imported
@@ -45,6 +46,7 @@ export default async function SvgChunkWebpackLoader(
 	);
 	if (typeof plugin === 'undefined') {
 		callback(new Error(`${PACKAGE_NAME} requires the corresponding plugin`));
+		return;
 	}
 
 	try {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -31,14 +31,12 @@ export default async function SvgChunkWebpackLoader(
 		(plugin: any) => plugin.PLUGIN_NAME && plugin.PLUGIN_NAME === PACKAGE_NAME
 	);
 	if (typeof plugin === 'undefined') {
-		callback(new Error(`${PACKAGE_NAME} requires the corresponding plugin`));
-		return;
+		return callback(new Error(`${PACKAGE_NAME} requires the corresponding plugin`));
 	}
 
 	// Check if content is a SVG file
 	if (!content.includes('<svg')) {
-		callback(new Error(`${PACKAGE_NAME} exception. ${content}`));
-		return;
+		return callback(new Error(`${PACKAGE_NAME} exception. ${content}`));
 	}
 
 	// Declare all SVG files as side effect

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -105,8 +105,12 @@ describe('Loader with errors', () => {
 	it('Should call the loader function with a wrong SVG', async () => {
 		await loader.call(_this, 'wrong svg');
 
-		expect.assertions(1);
+		expect.assertions(3);
+		expect(callback).toHaveBeenCalledTimes(1);
 		expect(callback).toHaveBeenCalledWith(new Error(`${PACKAGE_NAME} exception. wrong svg`));
+
+		// Don't set to process if SVG is bad.
+		expect(_this._module.buildInfo.SVG_CHUNK_WEBPACK_PLUGIN).toBeUndefined();
 	});
 
 	it('Should call the loader function without the plugin imported', async () => {
@@ -114,9 +118,13 @@ describe('Loader with errors', () => {
 
 		await loader.call(_this, '<svg></svg>');
 
-		expect.assertions(1);
+		expect.assertions(3);
+		expect(callback).toHaveBeenCalledTimes(1);
 		expect(callback).toHaveBeenCalledWith(
 			new Error(`${PACKAGE_NAME} requires the corresponding plugin`)
 		);
+
+		// Don't set to process if No Plugin is set to process it
+		expect(_this._module.buildInfo.SVG_CHUNK_WEBPACK_PLUGIN).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Description

Callbacks were being called multiple times causing incorrect messages in WebPack.  Also, if an SVG file was invalid the code was marking the SVG file for processing resulting in some pretty ugly errors when calculating etags.

Fixes: https://github.com/yoriiis/svg-chunk-webpack-plugin/issues/27

## Specific Changes proposed
Reordered pre-conditions checks towards the top of loader.ts.  Returned when the callback was called, instead of letting it "fall through", updated tests to catch issue, and ran Prettier.

## Requirements Checklist
- [X] Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Docs/guides updated
  - [ ] Example created on CodePen
- [ ] Reviewed by contributors
